### PR TITLE
Add basic tradingbot package

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,4 +5,5 @@ A skeletal Python bot that will evolve with the help of OpenAI Codex.
 ```bash
 python -m venv .venv && source .venv/bin/activate
 pip install -r requirements.txt
-
+python -m tradingbot.main
+```

--- a/src/tradingbot/__init__.py
+++ b/src/tradingbot/__init__.py
@@ -1,0 +1,2 @@
+"""Trading bot package."""
+

--- a/src/tradingbot/main.py
+++ b/src/tradingbot/main.py
@@ -1,0 +1,9 @@
+"""Entry point for the trading bot."""
+
+def main() -> None:
+    """Print a startup message."""
+    print("Bot starting...")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add `tradingbot` package under `src`
- implement simple entry point printing `Bot starting...`
- mention entry point in README

## Testing
- `PYTHONPATH=src python -m tradingbot.main`

------
https://chatgpt.com/codex/tasks/task_e_684046314558832c83ed22ebf0a85195