### PR TITLE
Add SMA trading strategy

### DIFF
--- a/src/tradingbot/strategies.py
+++ b/src/tradingbot/strategies.py
@@ -1,0 +1,56 @@
+from __future__ import annotations
+
+from abc import ABC, abstractmethod
+
+import pandas as pd
+
+
+class TradingStrategy(ABC):
+    """Abstract base class for trading strategies."""
+
+    @abstractmethod
+    def should_buy(self, prices: pd.Series) -> bool:
+        """Return True if a buy signal is generated given price history."""
+        raise NotImplementedError
+
+    @abstractmethod
+    def should_sell(self, prices: pd.Series) -> bool:
+        """Return True if a sell signal is generated given price history."""
+        raise NotImplementedError
+
+
+class SmaCrossStrategy(TradingStrategy):
+    """Simple moving average cross over strategy."""
+
+    def __init__(self, short_window: int, long_window: int) -> None:
+        if short_window >= long_window:
+            raise ValueError("short_window must be less than long_window")
+        self.short_window = short_window
+        self.long_window = long_window
+
+    def _has_enough_data(self, prices: pd.Series) -> bool:
+        return len(prices) >= self.long_window + 1
+
+    def _sma(self, prices: pd.Series, window: int) -> pd.Series:
+        return prices.rolling(window).mean()
+
+    def should_buy(self, prices: pd.Series) -> bool:
+        if not self._has_enough_data(prices):
+            return False
+        short_sma = self._sma(prices, self.short_window)
+        long_sma = self._sma(prices, self.long_window)
+        prev_short, prev_long = short_sma.iloc[-2], long_sma.iloc[-2]
+        last_short, last_long = short_sma.iloc[-1], long_sma.iloc[-1]
+        return prev_short <= prev_long and last_short > last_long
+
+    def should_sell(self, prices: pd.Series) -> bool:
+        if not self._has_enough_data(prices):
+            return False
+        short_sma = self._sma(prices, self.short_window)
+        long_sma = self._sma(prices, self.long_window)
+        prev_short, prev_long = short_sma.iloc[-2], long_sma.iloc[-2]
+        last_short, last_long = short_sma.iloc[-1], long_sma.iloc[-1]
+        return prev_short >= prev_long and last_short < last_long
+
+
+__all__ = ["TradingStrategy", "SmaCrossStrategy"]

--- a/tests/test_strategies.py
+++ b/tests/test_strategies.py
@@ -1,0 +1,17 @@
+import pandas as pd
+
+from tradingbot.strategies import SmaCrossStrategy
+
+
+def test_sma_cross_buy():
+    prices = pd.Series([1, 2, 3, 4, 5, 5, 5, 5, 5, 5, 6], dtype=float)
+    strat = SmaCrossStrategy(short_window=3, long_window=5)
+    assert strat.should_buy(prices) is True
+    assert strat.should_sell(prices) is False
+
+
+def test_sma_cross_sell():
+    prices = pd.Series([9, 9, 9, 9, 9, 8, 8, 8, 8, 8, 7], dtype=float)
+    strat = SmaCrossStrategy(short_window=3, long_window=5)
+    assert strat.should_sell(prices) is True
+    assert strat.should_buy(prices) is False


### PR DESCRIPTION
## Summary
- define `TradingStrategy` abstract base class
- implement minimal `SmaCrossStrategy`
- add unit tests for SMA cross strategy

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_684046362448832c964984f488ff3a49